### PR TITLE
Fix PostgreSQL version at 17

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   database:
-    image: 'postgres:latest'
+    image: 'postgres:17' # NOTE:  Will _NOT_ work >= 18 ('latest' will break this)
     ports:
       - 15432:5432
     env_file:
@@ -22,6 +22,9 @@ services:
     networks:
       - postgres-network
     volumes:
+      # REQUIRED BEFORE BRINGING UP THE STACK
+      #      $ chown -R 5050:5050 ${PWD}/pgadmin-data
+      # (ref: https://www.pgadmin.org/docs/pgadmin4/latest/container_deployment.html#mapped-files-and-directories)
       - ${PWD}/pgadmin-data/:/var/lib/pgadmin/
 
 networks: 


### PR DESCRIPTION
PostgreSQL 18 breaks this stack.  To make it work with 17 (or earlier), the 'latest' tag needs to be replaced with the version ('17', '16', etc.).  

Additionally, a comment was added indicating the that host data folder needs to have it's owner changed to match what pgadmin expects (5050:5050).